### PR TITLE
Move `wiki/build.py` into the outermost folder

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -19,9 +19,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.11'
-#     - name: Run build script
-#       run: |
-#         python wiki/build.py
+      - name: Run build script
+        run: |
+          python build_wiki.py
 
   publish:
     runs-on: ubuntu-latest

--- a/build_wiki.py
+++ b/build_wiki.py
@@ -4,7 +4,7 @@ import os
 from functools import total_ordering
 from importlib import import_module
 
-from template import *
+from wiki.template import *
 
 
 @total_ordering


### PR DESCRIPTION
I think this is the least-worst option given the constraints here; repositories regularly have build tools in their outermost scopes. Regardless, the decision on whether to merge this PR is yours, @kg583