### PR TITLE
Switch to pydoctor for API docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,10 @@ name: Publish docs
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+    
 
 jobs:
   build:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,32 +4,45 @@ on:
   push:
     branches: [ "main" ]
 
-    # Alternative: only build for tags.
-    # tags: [ "*" ]
-
-permissions:
-  contents: read
-
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout lib with submodules
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
-      - name: Run pdoc
-        run: |
-          pip install pdoc
-          pdoc tivars --math -o docs/
-      - name: Upload pages artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: docs/
+    - name: Checkout lib with submodules
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+
+    - name: Install pydoctor
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install docutils pydoctor
+
+    - name: Generate docs
+      run: |
+        pydoctor \
+            --project-name=tivars_lib_py \
+            --project-url=https://github.com/$GITHUB_REPOSITORY \
+            --html-viewsource-base=https://github.com/$GITHUB_REPOSITORY/tree/$GITHUB_SHA \
+            --theme readthedocs \
+            --make-html \
+            --html-output=./docs \
+            --project-base-dir="$(pwd)" \
+            --docformat=restructuredtext \
+            --intersphinx=https://docs.python.org/3/objects.inv \
+            ./tivars
+
+    - name: Upload pages artifact
+      uses: actions/upload-pages-artifact@v1
+      with:
+        path: docs/
+
 
   deploy:
     needs: build

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/tivars/data.py
+++ b/tivars/data.py
@@ -83,6 +83,7 @@ class Data(Bytes):
 
         Certain metadata fields are updated automatically based on the entry's data.
         The following are set by this converter:
+
             - Version
             - Length (for sized data)
 
@@ -280,12 +281,7 @@ class Section:
     Distinct data sections are entirely independent, which is useful for sections which may vary in length.
     To construct sections which point to a portion of another section, see the `View` class.
 
-    Data sections can be declared by decorating methods:
-    ```py
-    @Section(length, Converter)
-    def data_section(self) -> _T:
-        ...
-    ```
+    Data sections can be declared by decorating methods.
 
     An optional second parameter can be passed, wherein the method is used as a pre-converter before `Converter.set`.
     """
@@ -385,12 +381,7 @@ class View(Section):
     Data views are effectively pointers to the data sections they view, converting data in and out as specified.
     Note that data views cannot target other data views; this is done for implementation simplicity.
 
-    Data views can be declared by decorating methods:
-    ```py
-    @View(section[slice], Converter)
-    def data_view(self) -> _T:
-        ...
-    ```
+    Data views can be declared by decorating methods.
 
     An optional second parameter can be passed, wherein the method is used as a pre-converter before `Converter.set`.
     """
@@ -470,12 +461,7 @@ class Loader:
     """
     Function decorator to identify methods as data loaders for `Dock` instances
 
-    Specify the loader's accepted type(s) using brackets:
-    ```py
-    @Loader[int]
-    def load_int(self, data: int):
-        ...
-    ```
+    Specify the loader's accepted type(s) using brackets.
     """
 
     types = ()


### PR DESCRIPTION
The transition should be almost seamless, but certain Markdown elements need to be converted to restructuredText. The Actions checks for this PR should slowly but surely weed them out.